### PR TITLE
Syntax highlight DAML in Github UI as if it were Haskell

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.daml linguist-language=Haskell


### PR DESCRIPTION
That is not perfect but definitely better than the status quo. It's also what
we use in the daml repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/ex-cdm-swaps/25)
<!-- Reviewable:end -->
