### PR TITLE
Fix sandbox split navigator docker

### DIFF
--- a/Dockerfile-navigator
+++ b/Dockerfile-navigator
@@ -7,12 +7,12 @@ ARG sdk_version=0.13.22
 
 FROM digitalasset/daml-sdk:${sdk_version}
 
-EXPOSE 4000
-
 RUN mkdir src
 WORKDIR /home/daml/src
 COPY daml daml
 COPY daml.yaml frontend-config.js ui-backend.conf ./
 RUN daml build
+
+EXPOSE 4000
 
 CMD daml navigator server ${LEDGER_HOST} ${LEDGER_PORT}

--- a/Dockerfile-navigator
+++ b/Dockerfile-navigator
@@ -8,7 +8,6 @@ ARG sdk_version=0.13.22
 FROM digitalasset/daml-sdk:${sdk_version}
 
 EXPOSE 4000
-EXPOSE 6865
 
 RUN mkdir src
 WORKDIR /home/daml/src
@@ -16,5 +15,4 @@ COPY daml daml
 COPY daml.yaml frontend-config.js ui-backend.conf ./
 RUN daml build
 
-CMD daml sandbox .daml/dist/CdmSwaps-1.0.0.dar & \
-    daml navigator server
+CMD daml navigator server ${LEDGER_HOST} ${LEDGER_PORT}

--- a/Dockerfile-sandbox
+++ b/Dockerfile-sandbox
@@ -9,8 +9,8 @@ FROM digitalasset/daml-sdk:${sdk_version}
 
 RUN mkdir src
 WORKDIR /home/daml/src
-COPY daml.yaml frontend-config.js ui-backend.conf ./
 COPY daml daml
+COPY daml.yaml frontend-config.js ui-backend.conf ./
 RUN daml build
 
 EXPOSE 6865

--- a/Dockerfile-sandbox
+++ b/Dockerfile-sandbox
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ARG sdk_version=0.13.22
+
+FROM digitalasset/daml-sdk:${sdk_version}
+
+EXPOSE 6865
+
+RUN mkdir src
+WORKDIR /home/daml/src
+COPY daml.yaml frontend-config.js ui-backend.conf ./
+COPY daml daml
+RUN daml build
+
+CMD daml sandbox .daml/dist/CdmSwaps-1.0.0.dar

--- a/Dockerfile-sandbox
+++ b/Dockerfile-sandbox
@@ -7,12 +7,12 @@ ARG sdk_version=0.13.22
 
 FROM digitalasset/daml-sdk:${sdk_version}
 
-EXPOSE 6865
-
 RUN mkdir src
 WORKDIR /home/daml/src
 COPY daml.yaml frontend-config.js ui-backend.conf ./
 COPY daml daml
 RUN daml build
+
+EXPOSE 6865
 
 CMD daml sandbox .daml/dist/CdmSwaps-1.0.0.dar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,23 +5,34 @@
 
 version: '2'
 services:
-  cdm-swaps-daml:
-    image: digitalasset/cdm-swaps-daml:0.0.1
+  cdm-swaps-sandbox:
+    image: digitalasset/cdm-swaps-sandbox:0.0.1
     build:
       context: .
-      dockerfile: Dockerfile-daml
+      dockerfile: Dockerfile-sandbox
+    ports:
+      - "6865:6865"
+  cdm-swaps-navigator:
+    image: digitalasset/cdm-swaps-navigator:0.0.1
+    build:
+      context: .
+      dockerfile: Dockerfile-navigator
+    environment:
+      - LEDGER_HOST=cdm-swaps-sandbox
+      - LEDGER_PORT=6865
+    depends_on:
+      - "cdm-swaps-sandbox"
     ports:
       - "4000:4000"
-      - "6865:6865"
   cdm-swaps-bots:
     image: digitalasset/cdm-swaps-bots:0.0.1
     build:
       context: .
       dockerfile: Dockerfile-bots
     depends_on:
-      - "cdm-swaps-daml"
+      - "cdm-swaps-sandbox"
     environment:
-      - LEDGER_HOST=cdm-swaps-daml
+      - LEDGER_HOST=cdm-swaps-sandbox
       - LEDGER_PORT=6865
       - INCLUDE_DEMO=true
   cdm-swaps-repl:
@@ -32,7 +43,7 @@ services:
       context: .
       dockerfile: Dockerfile-repl
     depends_on:
-      - "cdm-swaps-daml"
+      - "cdm-swaps-sandbox"
     environment:
-      - LEDGER_HOST=cdm-swaps-daml
+      - LEDGER_HOST=cdm-swaps-sandbox
       - LEDGER_PORT=6865


### PR DESCRIPTION
split navigator and sandbox to different containers.

still leads to OOM even when 10gb memory is allocated to docker on OSX